### PR TITLE
Plugin Store

### DIFF
--- a/client/src/plugins/TestPlugin.tsx
+++ b/client/src/plugins/TestPlugin.tsx
@@ -1,0 +1,7 @@
+import { Typography } from '@material-ui/core';
+
+const TestPlugin = (): JSX.Element => {
+  return <Typography>TEST PLUGIN</Typography>;
+};
+
+export default TestPlugin;

--- a/client/src/plugins/pluginStore.ts
+++ b/client/src/plugins/pluginStore.ts
@@ -1,0 +1,15 @@
+import TestPlugin from './TestPlugin';
+import React from 'react';
+
+interface PluginComponentList {
+  [key: string]: React.FC;
+}
+
+//Register all plugins here. pluginKey : pluginComponent
+const pluginComponentList: PluginComponentList = {
+  testPlugin: TestPlugin,
+};
+
+export const getPluginComponent = (pluginKey: string): React.FC => {
+  return pluginComponentList[pluginKey];
+};


### PR DESCRIPTION
### What this PR does (required):
- Creates a plugin store - simple js object which has the plugin components registered. 
- A function is exported to grab the component based on the plugin key.

### Any issues with the current functionality (optional):
- No Tests
